### PR TITLE
Feat/update package

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 A laravel package to generate files for layered architecture and automate interface bindings.
 
-**Recommended Laravel version:** `^9.0`
+**Recommended Laravel version:** `^12.0`
 
-Go to [Laravel Docs](https://laravel.com/docs/9.x/releases#support-policy) to see support policy.
+Go to [Laravel Docs](https://laravel.com/docs/releases#support-policy) to see support policy.
 
 ## Summary
 - <a href="#requirements">Requirements</a>
@@ -14,14 +14,15 @@ Go to [Laravel Docs](https://laravel.com/docs/9.x/releases#support-policy) to se
   - <a href="#generate-layers">Generate Layers</a>
   - <a href="#generate-layers-with-subfolders">Generate Layers with Subfolders</a>
   - <a href="#generate-services-with-more-than-one-repository">Generate Services with more than one repository</a>
+  - <a href="#scaffold-layers-from-models">Scaffold Layers from Models</a>
 
 ## Requirements
 
 ```json
-"php": "^8.0.2"
-"symfony/finder": "^6.3"
-"illuminate/support": "^9.0 || ^10.20"
-"illuminate/console": "^9.0 || ^10.20"
+"php": "^8.2"
+"symfony/finder": "^6.3 || ^7.0"
+"illuminate/support": "^9.0 || ^10.20 || ^11.0 || ^12.0"
+"illuminate/console": "^9.0 || ^10.20 || ^11.0 || ^12.0"
 ```
 
 ## Installation
@@ -78,7 +79,8 @@ Available options:
 - `php artisan layers:repository --eloquent` : the same as ***php artisan layers --eloquent***
 - `php artisan layers:repository --interface` : the same as ***php artisan layers --interface***
 - `php artisan layers:service` : the same as ***php artisan layers --service***
-- `php artisan layers:binds` : List all binds from application 
+- `php artisan layers:binds` : List all binds from application
+- `php artisan layers:scaffold` : Scaffold repositories and services for all models
 
 ### Generate Layers
 ```bash
@@ -96,9 +98,13 @@ php artisan layers --all User
 ```php
 <?php
 
-namespace App\Repositories\User;
+declare(strict_types=1);
+
+namespace App\Repositories;
 
 use App\Models\User;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Support\Collection as SupportCollection;
 
 interface UserRepositoryInterface
 {
@@ -106,40 +112,40 @@ interface UserRepositoryInterface
 
     /**
      * Stores a new instance of User in the database
-     * @param \Illuminate\Support\Collection|array|int|string $data
+     * @param SupportCollection|array|int|string $data
      * @return User
      */
-    public function store($data);
+    public function store(SupportCollection|array|int|string $data): User;
 
     /**
      * Returns all instances of User from the database
      * @param array|string $columns
-     * @param array<array> $filters
-     * @return \Illuminate\Database\Eloquent\Collection<int, static>
+     * @param array<array>|null $filters
+     * @return Collection<int, User>
      */
-    public function getList($columns=['*'], $filters=null);
+    public function getList(array|string $columns = ['*'], ?array $filters = null): Collection;
 
     /**
      * Returns an instance of User from the given id
      * @param int|string $id
-     * @return User
+     * @return User|null
      */
-    public function get($id);
+    public function get(int|string $id): ?User;
 
     /**
      * Updates the data of an instance of User
-     * @param \Illuminate\Support\Collection|array|int|string $data
+     * @param SupportCollection|array|int|string $data
      * @param int|string $id
      * @return User
      */
-    public function update($data, $id);
+    public function update(SupportCollection|array|int|string $data, int|string $id): User;
 
     /**
      * Removes an instance of User from the database
      * @param int|string $id
-     * @return int
+     * @return bool
      */
-    public function destroy($id);
+    public function destroy(int|string $id): bool;
 }
 ```
 
@@ -147,25 +153,26 @@ interface UserRepositoryInterface
 ```php
 <?php
 
+declare(strict_types=1);
+
 namespace App\Repositories;
 
 use App\Models\User;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Support\Collection as SupportCollection;
 
 class UserRepositoryEloquent implements UserRepositoryInterface
 {
-    protected $user;
-
-    public function __construct(User $user)
-    {
-        $this->user = $user;
-    }
+    public function __construct(
+        protected User $user,
+    ) {}
 
     /**
      * Stores a new instance of User in the database
-     * @param \Illuminate\Support\Collection|array|int|string $data
+     * @param SupportCollection|array|int|string $data
      * @return User
      */
-    public function store($data)
+    public function store(SupportCollection|array|int|string $data): User
     {
         return $this->user->create($data);
     }
@@ -173,53 +180,61 @@ class UserRepositoryEloquent implements UserRepositoryInterface
     /**
      * Returns all instances of User from the database
      * @param array|string $columns
-     * @param array<array> $filters
-     * @return \Illuminate\Database\Eloquent\Collection<int, static>
+     * @param array<array>|null $filters
+     * @return Collection<int, User>
      */
-    public function getList($columns=['*'], $filters=null)
+    public function getList(array|string $columns = ['*'], ?array $filters = null): Collection
     {
-        return $this->user->where($filters)->get($columns);
+        $query = $this->user->newQuery();
+
+        if ($filters) {
+            $query->where($filters);
+        }
+
+        return $query->get($columns);
     }
 
     /**
      * Returns an instance of User from the given id
      * @param int|string $id
-     * @return User
+     * @return User|null
      */
-    public function get($id)
+    public function get(int|string $id): ?User
     {
         return $this->user->find($id);
     }
 
     /**
      * Updates the data of an instance of User
-     * @param \Illuminate\Support\Collection|array|int|string $data
+     * @param SupportCollection|array|int|string $data
      * @param int|string $id
      * @return User
      */
-    public function update($data, $id)
+    public function update(SupportCollection|array|int|string $data, int|string $id): User
     {
-        $user = $this->user->find($id);
+        $user = $this->user->findOrFail($id);
         $user->update($data);
+
         return $user;
     }
 
     /**
      * Removes an instance of User from the database
      * @param int|string $id
-     * @return int
+     * @return bool
      */
-    public function destroy($id)
+    public function destroy(int|string $id): bool
     {
-        return $this->user->find($id)->delete();
+        return (bool) $this->user->findOrFail($id)->delete();
     }
 }
-
 ```
 
 #### UserService.php
 ```php
 <?php
+
+declare(strict_types=1);
 
 namespace App\Services;
 
@@ -227,18 +242,12 @@ use App\Repositories\UserRepositoryInterface;
 
 class UserService
 {
-    private $repoUser;
-
     public function __construct(
-        UserRepositoryInterface $repoUser,
-    )
-    {
-        $this->repoUser = $repoUser;
-    }
+        protected UserRepositoryInterface $repoUser,
+    ) {}
 
     // Add your functions here...
 }
-
 ```
 
 ### Generate Layers with Subfolders
@@ -262,6 +271,8 @@ php artisan layers --service --wr=Address --wr=User Person
 ```php
 <?php
 
+declare(strict_types=1);
+
 namespace App\Services;
 
 use App\Repositories\UserRepositoryInterface;
@@ -275,13 +286,52 @@ class PersonService
     public function __construct(
         AddressRepositoryInterface $repoAddress,
         UserRepositoryInterface $repoUser,
-    )
-    {
+    ) {
         $this->repoAddress = $repoAddress;
         $this->repoUser = $repoUser;
     }
 
     // Add your functions here...
 }
+```
+
+### Scaffold Layers from Models
+
+Instead of generating files one by one, you can scaffold repositories for all models at once:
+
+```bash
+php artisan layers:scaffold
+```
+
+This command scans the models directory (configured in `layers.path.models`) and generates an Interface and Eloquent pair for every model found.
+
+**Example** — given the following models:
 
 ```
+app/Models/
+├── User.php
+├── Company.php
+└── Auth/
+    └── Token.php
+```
+
+Running `layers:scaffold` generates:
+
+```
+app/Repositories/
+├── UserRepositoryInterface.php
+├── UserRepositoryEloquent.php
+├── CompanyRepositoryInterface.php
+├── CompanyRepositoryEloquent.php
+└── Auth/
+    ├── TokenRepositoryInterface.php
+    └── TokenRepositoryEloquent.php
+```
+
+To also generate a service for each model, use the `--with-service` flag:
+
+```bash
+php artisan layers:scaffold --with-service
+```
+
+If a file already exists, it will be skipped automatically — no files are overwritten.

--- a/composer.json
+++ b/composer.json
@@ -15,10 +15,10 @@
         }
     ],
     "require": {
-        "php": "^8.0.2",
-        "symfony/finder": "^6.3",
-        "illuminate/support": "^9.0 || ^10.20",
-        "illuminate/console": "^9.0 || ^10.20"
+        "php": "^8.2",
+        "symfony/finder": "^6.3 || ^7.0",
+        "illuminate/support": "^9.0 || ^10.20 || ^11.0 || ^12.0",
+        "illuminate/console": "^9.0 || ^10.20 || ^11.0 || ^12.0"
     },
     "extra": {
         "laravel": {

--- a/src/Console/Commands/ListBinds.php
+++ b/src/Console/Commands/ListBinds.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace WilliamJSS\Layers\Console\Commands;
 
 use Illuminate\Console\Command;
@@ -28,7 +30,7 @@ class ListBinds extends Command
      *
      * @return int
      */
-    public function handle()
+    public function handle(): int
     {
         $path = config('layers.path.repositories');
 
@@ -38,10 +40,10 @@ class ListBinds extends Command
             $merge = collect();
             for ($i = 0; $i <= 2; $i++) {
                 $folders = collect((new Finder)->files()->depth($i)->in($path))
-                ->map(fn($file) => $file->getBasename('.php'))
-                ->collect()
-                ->all();
-                
+                    ->map(fn($file) => $file->getBasename('.php'))
+                    ->collect()
+                    ->all();
+
                 $merge = $merge->merge($folders);
             }
 
@@ -53,15 +55,17 @@ class ListBinds extends Command
                     return str_replace('Interface', '', $model);
                 }
             })->values()->all();
-            
-            # Bind repositories interfaces/eloquents
+
+            # List repositories interfaces/eloquents
             foreach ($models as $model) {
                 if ($model != null) {
-                    echo(str_replace('/', '\\', Str::ucfirst($model)) . 'Interface' . "\n");
-                    echo(str_replace('/', '\\', Str::ucfirst($model)) . 'Eloquent' . "\n\n");
+                    $this->line(str_replace('/', '\\', Str::ucfirst($model)) . 'Interface');
+                    $this->line(str_replace('/', '\\', Str::ucfirst($model)) . 'Eloquent');
+                    $this->newLine();
                 }
             }
         }
-    }
 
+        return Command::SUCCESS;
+    }
 }

--- a/src/Console/Commands/MakeLayer.php
+++ b/src/Console/Commands/MakeLayer.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace WilliamJSS\Layers\Console\Commands;
 
 use Illuminate\Console\Command;
@@ -33,7 +35,7 @@ class MakeLayer extends Command
      *
      * @return int
      */
-    public function handle()
+    public function handle(): int
     {
         $name = $this->argument('name');
         $options = $this->options();
@@ -54,11 +56,11 @@ class MakeLayer extends Command
         }
 
         if ($options['interface']) {
-            $this->call('layers:repository', ['name' => $name, '--eloquent' => true]);
+            $this->call('layers:repository', ['name' => $name, '--interface' => true]);
         }
 
         if ($options['eloquent']) {
-            $this->call('layers:repository', ['name' => $name, '--interface' => true]);
+            $this->call('layers:repository', ['name' => $name, '--eloquent' => true]);
         }
 
         if ($options['service']) {
@@ -67,6 +69,4 @@ class MakeLayer extends Command
 
         return Command::SUCCESS;
     }
-
 }
-

--- a/src/Console/Commands/MakeRepository.php
+++ b/src/Console/Commands/MakeRepository.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace WilliamJSS\Layers\Console\Commands;
 
-use Illuminate\Console\Command;
 use Illuminate\Console\GeneratorCommand;
 use Illuminate\Support\Str;
 use InvalidArgumentException;
@@ -29,7 +30,7 @@ class MakeRepository extends GeneratorCommand
 
     protected $type = 'Repository file';
 
-    protected function getNameInput()
+    protected function getNameInput(): string
     {
         return str_replace('.', '/', trim($this->argument('name')));
     }
@@ -39,7 +40,7 @@ class MakeRepository extends GeneratorCommand
      *
      * @return string
      */
-    protected function getStub()
+    protected function getStub(): string
     {
         $stubs_path = base_path('vendor/williamjss/layers') . '/src/Console/Commands/Stubs/';
         return $stubs_path . 'Repository' . $this->getType() . '.stub';
@@ -51,7 +52,7 @@ class MakeRepository extends GeneratorCommand
      * @param  string  $rootNamespace
      * @return string
      */
-    protected function getDefaultNamespace($rootNamespace)
+    protected function getDefaultNamespace($rootNamespace): string
     {
         return $rootNamespace . '\\' . config('layers.namespace.repositories');
     }
@@ -62,7 +63,7 @@ class MakeRepository extends GeneratorCommand
      * @param  string  $name
      * @return string
      */
-    protected function getPath($name)
+    protected function getPath($name): string
     {
         $name = Str::replaceFirst($this->rootNamespace(), '', $name);
 
@@ -75,13 +76,11 @@ class MakeRepository extends GeneratorCommand
      * @param  string  $name
      * @return string
      */
-    protected function buildClass($name)
+    protected function buildClass($name): string
     {
         $stub = parent::buildClass($name);
 
-        $model = $name;
-
-        return $model ? $this->replaceModel($stub, $model) : $stub;
+        return $this->replaceModel($stub, $name);
     }
 
     /**
@@ -91,7 +90,7 @@ class MakeRepository extends GeneratorCommand
      * @param  string  $model
      * @return string
      */
-    protected function replaceModel($stub, $model)
+    protected function replaceModel($stub, $model): string
     {
         $modelClass = $this->parseModel($model);
 
@@ -114,7 +113,7 @@ class MakeRepository extends GeneratorCommand
      *
      * @throws \InvalidArgumentException
      */
-    protected function parseModel($model)
+    protected function parseModel(string $model): string
     {
         if (preg_match('([^A-Za-z0-9_/\\\\])', $model)) {
             throw new InvalidArgumentException('Model name contains invalid characters.');
@@ -124,29 +123,24 @@ class MakeRepository extends GeneratorCommand
     }
 
     /**
-     * Get the repository type
+     * Get the repository type.
      *
      * @return string
+     *
+     * @throws \InvalidArgumentException
      */
-    protected function getType()
+    protected function getType(): string
     {
         $options = $this->options();
+
         if ($options['eloquent'] && $options['interface']) {
             throw new InvalidArgumentException('More than one option provided: expected \'eloquent\' or \'interface\', not both.');
+        } elseif ($options['eloquent']) {
+            return 'Eloquent';
+        } elseif ($options['interface']) {
+            return 'Interface';
         }
 
-        else if ($options['eloquent']) {
-            $type = 'Eloquent';
-        }
-
-        else if ($options['interface']) {
-            $type = 'Interface';
-        }
-
-        else {
-            throw new InvalidArgumentException('Invalid option: expected \'eloquent\' or \'interface\'.');
-        }
-
-        return $type;
+        throw new InvalidArgumentException('Invalid option: expected \'eloquent\' or \'interface\'.');
     }
 }

--- a/src/Console/Commands/MakeService.php
+++ b/src/Console/Commands/MakeService.php
@@ -1,8 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 namespace WilliamJSS\Layers\Console\Commands;
 
-use Illuminate\Console\Command;
 use Illuminate\Console\GeneratorCommand;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Str;
@@ -30,7 +31,7 @@ class MakeService extends GeneratorCommand
 
     protected $type = 'Service file';
 
-    protected function getNameInput()
+    protected function getNameInput(): string
     {
         return str_replace('.', '/', trim($this->argument('name')));
     }
@@ -40,15 +41,15 @@ class MakeService extends GeneratorCommand
      *
      * @return string
      */
-    protected function getStub()
+    protected function getStub(): string
     {
         $stubs_path = base_path('vendor/williamjss/layers') . '/src/Console/Commands/Stubs/';
-        
+
         if ($this->withRepositories()) {
             return $stubs_path . 'ServiceMultiRepositories.stub';
-        } else {
-            return $stubs_path . 'Service.stub';
         }
+
+        return $stubs_path . 'Service.stub';
     }
 
     /**
@@ -57,7 +58,7 @@ class MakeService extends GeneratorCommand
      * @param  string  $rootNamespace
      * @return string
      */
-    protected function getDefaultNamespace($rootNamespace)
+    protected function getDefaultNamespace($rootNamespace): string
     {
         return $rootNamespace . '\\' . config('layers.namespace.services');
     }
@@ -68,7 +69,7 @@ class MakeService extends GeneratorCommand
      * @param  string  $name
      * @return string
      */
-    protected function getPath($name)
+    protected function getPath($name): string
     {
         $name = Str::replaceFirst($this->rootNamespace(), '', $name);
 
@@ -81,13 +82,11 @@ class MakeService extends GeneratorCommand
      * @param  string  $name
      * @return string
      */
-    protected function buildClass($name)
+    protected function buildClass($name): string
     {
         $stub = parent::buildClass($name);
 
-        $model = $name;
-
-        return $model ? $this->replaceModel($stub, $model) : $stub;
+        return $this->replaceModel($stub, $name);
     }
 
     /**
@@ -97,9 +96,9 @@ class MakeService extends GeneratorCommand
      * @param  string  $model
      * @return string
      */
-    protected function replaceModel($stub, $model)
+    protected function replaceModel($stub, $model): string
     {
-        if ($this->options()['wr']){
+        if ($this->options()['wr']) {
             $repositories = '';
             $variables = '';
             $construct = '';
@@ -117,9 +116,8 @@ class MakeService extends GeneratorCommand
                 '{{ thisConstruct }}' => $thisConstruct,
             ];
         } else {
-            $namespaceRepo = $this->parseModel($model);
             $replace = [
-                '{{ namespaceRepository }}' => $namespaceRepo,
+                '{{ namespaceRepository }}' => $this->parseModel($model),
             ];
         }
 
@@ -138,7 +136,7 @@ class MakeService extends GeneratorCommand
      *
      * @throws \InvalidArgumentException
      */
-    protected function parseModel($model)
+    protected function parseModel(string $model): string
     {
         if (preg_match('([^A-Za-z0-9_/\\\\])', $model)) {
             throw new InvalidArgumentException('Model name contains invalid characters.');
@@ -152,8 +150,10 @@ class MakeService extends GeneratorCommand
      *
      * @param  string  $model
      * @return string
+     *
+     * @throws \InvalidArgumentException
      */
-    protected function qualifyModel(string $model)
+    protected function qualifyModel(string $model): string
     {
         $model = class_basename($model) . 'RepositoryInterface';
 
@@ -170,15 +170,16 @@ class MakeService extends GeneratorCommand
     }
 
     /**
-     * Get a possibles repositories namespace
+     * Get possible repositories namespaces.
      *
      * @return array<int, string>
+     * @throws \InvalidArgumentException
      */
-    protected function possiblesRepositories()
+    protected function possiblesRepositories(): array
     {
         $repoPath = config('layers.path.repositories');
 
-        if(!File::exists($repoPath)){
+        if (!File::exists($repoPath)) {
             throw new InvalidArgumentException('Invalid repository path: ' . $repoPath);
         }
 
@@ -206,15 +207,12 @@ class MakeService extends GeneratorCommand
     }
 
     /**
-     * Verify 'with-repositories' option
+     * Verify 'with-repositories' option.
      *
      * @return bool
      */
-    protected function withRepositories(){
-        if($this->options()['wr']){
-            return TRUE;
-        } else {
-            return FALSE;
-        }
+    protected function withRepositories(): bool
+    {
+        return (bool) $this->options()['wr'];
     }
 }

--- a/src/Console/Commands/ScaffoldLayers.php
+++ b/src/Console/Commands/ScaffoldLayers.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WilliamJSS\Layers\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\File;
+use Symfony\Component\Finder\Finder;
+
+class ScaffoldLayers extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = '
+        layers:scaffold
+        {--s|with-service : Also generate a service for each model}
+    ';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Scaffold repository interface and eloquent for every model found in the models directory';
+
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     */
+    public function handle(): int
+    {
+        $modelsPath = config('layers.path.models');
+
+        if (! File::exists($modelsPath)) {
+            $this->error("Models directory not found: {$modelsPath}");
+
+            return Command::FAILURE;
+        }
+
+        $models = $this->resolveModels($modelsPath);
+
+        if ($models->isEmpty()) {
+            $this->warn('No models found in: ' . $modelsPath);
+
+            return Command::SUCCESS;
+        }
+
+        $withService = $this->option('with-service');
+
+        $this->info('Scaffolding layers...');
+        $this->newLine();
+
+        foreach ($models as $name) {
+            $this->line($name);
+
+            $this->call('layers:repository', ['name' => $name, '--interface' => true]);
+            $this->call('layers:repository', ['name' => $name, '--eloquent' => true]);
+
+            if ($withService) {
+                $this->call('layers:service', ['name' => $name]);
+            }
+
+            $this->newLine();
+        }
+
+        $this->info('Done.');
+
+        return Command::SUCCESS;
+    }
+
+    /**
+     * Resolves model names relative to the models directory,
+     * preserving subdirectory structure.
+     *
+     * @return \Illuminate\Support\Collection<int, string>
+     */
+    protected function resolveModels(string $modelsPath): \Illuminate\Support\Collection
+    {
+        return collect((new Finder)->files()->name('*.php')->in($modelsPath))
+            ->map(function ($file) use ($modelsPath) {
+                $relative = str_replace([$modelsPath . DIRECTORY_SEPARATOR, '.php'], '', $file->getPathname());
+
+                return str_replace(DIRECTORY_SEPARATOR, '/', $relative);
+            })
+            ->values();
+    }
+}

--- a/src/Console/Commands/Stubs/RepositoryEloquent.stub
+++ b/src/Console/Commands/Stubs/RepositoryEloquent.stub
@@ -1,24 +1,25 @@
 <?php
 
+declare(strict_types=1);
+
 namespace {{ namespace }};
 
 use App\Models\{{ class }};
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Support\Collection as SupportCollection;
 
 class {{ class }}RepositoryEloquent implements {{ class }}RepositoryInterface
 {
-    protected ${{ modelVariable }};
-
-    public function __construct({{ class }} ${{ modelVariable }})
-    {
-        $this->{{ modelVariable }} = ${{ modelVariable }};
-    }
+    public function __construct(
+        protected {{ class }} ${{ modelVariable }},
+    ) {}
 
     /**
      * Stores a new instance of {{ class }} in the database
-     * @param \Illuminate\Support\Collection|array|int|string $data
+     * @param SupportCollection|array|int|string $data
      * @return {{ class }}
      */
-    public function store($data)
+    public function store(SupportCollection|array|int|string $data): {{ class }}
     {
         return $this->{{ modelVariable }}->create($data);
     }
@@ -26,44 +27,51 @@ class {{ class }}RepositoryEloquent implements {{ class }}RepositoryInterface
     /**
      * Returns all instances of {{ class }} from the database
      * @param array|string $columns
-     * @param array<array> $filters
-     * @return \Illuminate\Database\Eloquent\Collection<int, {{ class }}>
+     * @param array<array>|null $filters
+     * @return Collection<int, {{ class }}>
      */
-    public function getList($columns=['*'], $filters=null)
+    public function getList(array|string $columns = ['*'], ?array $filters = null): Collection
     {
-        return $this->{{ modelVariable }}->where($filters)->get($columns);
+        $query = $this->{{ modelVariable }}->newQuery();
+
+        if ($filters) {
+            $query->where($filters);
+        }
+
+        return $query->get($columns);
     }
 
     /**
      * Returns an instance of {{ class }} from the given id
      * @param int|string $id
-     * @return {{ class }}
+     * @return {{ class }}|null
      */
-    public function get($id)
+    public function get(int|string $id): ?{{ class }}
     {
         return $this->{{ modelVariable }}->find($id);
     }
 
     /**
      * Updates the data of an instance of {{ class }}
-     * @param \Illuminate\Support\Collection|array|int|string $data
+     * @param SupportCollection|array|int|string $data
      * @param int|string $id
      * @return {{ class }}
      */
-    public function update($data, $id)
+    public function update(SupportCollection|array|int|string $data, int|string $id): {{ class }}
     {
-        ${{ modelVariable }} = $this->{{ modelVariable }}->find($id);
+        ${{ modelVariable }} = $this->{{ modelVariable }}->findOrFail($id);
         ${{ modelVariable }}->update($data);
+
         return ${{ modelVariable }};
     }
 
     /**
      * Removes an instance of {{ class }} from the database
      * @param int|string $id
-     * @return int
+     * @return bool
      */
-    public function destroy($id)
+    public function destroy(int|string $id): bool
     {
-        return $this->{{ modelVariable }}->find($id)->delete();
+        return (bool) $this->{{ modelVariable }}->findOrFail($id)->delete();
     }
 }

--- a/src/Console/Commands/Stubs/RepositoryInterface.stub
+++ b/src/Console/Commands/Stubs/RepositoryInterface.stub
@@ -1,8 +1,12 @@
 <?php
 
+declare(strict_types=1);
+
 namespace {{ namespace }};
 
 use App\Models\{{ class }};
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Support\Collection as SupportCollection;
 
 interface {{ class }}RepositoryInterface
 {
@@ -10,38 +14,38 @@ interface {{ class }}RepositoryInterface
 
     /**
      * Stores a new instance of {{ class }} in the database
-     * @param \Illuminate\Support\Collection|array|int|string $data
+     * @param SupportCollection|array|int|string $data
      * @return {{ class }}
      */
-    public function store($data);
+    public function store(SupportCollection|array|int|string $data): {{ class }};
 
     /**
      * Returns all instances of {{ class }} from the database
      * @param array|string $columns
-     * @param array<array> $filters
-     * @return \Illuminate\Database\Eloquent\Collection<int, {{ class }}>
+     * @param array<array>|null $filters
+     * @return Collection<int, {{ class }}>
      */
-    public function getList($columns=['*'], $filters=null);
+    public function getList(array|string $columns = ['*'], ?array $filters = null): Collection;
 
     /**
      * Returns an instance of {{ class }} from the given id
      * @param int|string $id
-     * @return {{ class }}
+     * @return {{ class }}|null
      */
-    public function get($id);
+    public function get(int|string $id): ?{{ class }};
 
     /**
      * Updates the data of an instance of {{ class }}
-     * @param \Illuminate\Support\Collection|array|int|string $data
+     * @param SupportCollection|array|int|string $data
      * @param int|string $id
      * @return {{ class }}
      */
-    public function update($data, $id);
+    public function update(SupportCollection|array|int|string $data, int|string $id): {{ class }};
 
     /**
      * Removes an instance of {{ class }} from the database
      * @param int|string $id
-     * @return int
+     * @return bool
      */
-    public function destroy($id);
+    public function destroy(int|string $id): bool;
 }

--- a/src/Console/Commands/Stubs/Service.stub
+++ b/src/Console/Commands/Stubs/Service.stub
@@ -1,19 +1,16 @@
 <?php
 
+declare(strict_types=1);
+
 namespace {{ namespace }};
 
 use {{ namespaceRepository }};
 
 class {{ class }}Service
 {
-    private $repo{{ class }};
-
     public function __construct(
-        {{ class }}RepositoryInterface $repo{{ class }},
-    )
-    {
-        $this->repo{{ class }} = $repo{{ class }};
-    }
+        protected {{ class }}RepositoryInterface $repo{{ class }},
+    ) {}
 
     // Add your functions here...
 }

--- a/src/Console/Commands/Stubs/ServiceMultiRepositories.stub
+++ b/src/Console/Commands/Stubs/ServiceMultiRepositories.stub
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace {{ namespace }};
 {{ repositories }}
 
@@ -7,8 +9,7 @@ class {{ class }}Service
 {{{ variables }}
 
     public function __construct({{ construct }}
-    )
-    {{{ thisConstruct }}
+    ) {{{ thisConstruct }}
     }
 
     // Add your functions here...

--- a/src/Providers/LayersServiceProvider.php
+++ b/src/Providers/LayersServiceProvider.php
@@ -1,25 +1,28 @@
 <?php
 
+declare(strict_types=1);
+
 namespace WilliamJSS\Layers\Providers;
 
-use Illuminate\Support\Facades\File;
 use Illuminate\Support\ServiceProvider;
 use WilliamJSS\Layers\Console\Commands\MakeLayer;
 use WilliamJSS\Layers\Console\Commands\MakeRepository;
 use WilliamJSS\Layers\Console\Commands\MakeService;
 use WilliamJSS\Layers\Console\Commands\ListBinds;
+use WilliamJSS\Layers\Console\Commands\ScaffoldLayers;
 
 class LayersServiceProvider extends ServiceProvider
 {
-    public function register(){
-        $this->app->register('WilliamJSS\\Layers\\Providers\\RepositoryBindServiceProvider');
+    public function register(): void
+    {
+        $this->app->register(RepositoryBindServiceProvider::class);
 
         $this->mergeConfigFrom(
             __DIR__.'/../config/layers.php', 'layers'
         );
     }
 
-    public function boot()
+    public function boot(): void
     {
         if ($this->app->runningInConsole()) {
             $this->commands([
@@ -27,12 +30,12 @@ class LayersServiceProvider extends ServiceProvider
                 MakeRepository::class,
                 MakeService::class,
                 ListBinds::class,
+                ScaffoldLayers::class,
             ]);
-            
+
             $this->publishes([
                 __DIR__.'/../config/layers.php' => config_path('layers.php')
             ], 'layers');
         }
-
     }
 }

--- a/src/Providers/RepositoryBindServiceProvider.php
+++ b/src/Providers/RepositoryBindServiceProvider.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace WilliamJSS\Layers\Providers;
 
 use Illuminate\Support\Facades\File;


### PR DESCRIPTION
### Dependencies
- Updated minimum PHP to `^8.2`
- Added support for `symfony/finder ^7.0`
- Added support for `illuminate/support` and `illuminate/console` `^11.0 || ^12.0`

### Bug fix
- **Swapped options in `layers` command** — `--interface` was generating an eloquent and vice-versa

### Code quality
- Added `declare(strict_types=1)` to all PHP files and stubs
- Added return type hints to all command and provider methods
- Replaced `echo()` with `$this->line()` / `$this->newLine()` in `ListBinds`
- Removed unused imports
- Minor code style improvements (early returns, consistent spacing)

### Stubs modernization
- Constructor property promotion in repository and service stubs
- Native union type hints on method signatures while **preserving the original broad parameter types** (`SupportCollection|array|int|string`)
- `getList()` now uses `newQuery()` with conditional filter (fixes error when `$filters` is null)
- `findOrFail()` instead of `find()` in `update()` and `destroy()`
- `destroy()` now returns `bool` instead of `int`
- `get()` now correctly returns nullable (`?Model`)

### New feature
- **`layers:scaffold` command** — generates repository interface and eloquent for every model found in the models directory, with optional `--with-service` flag

### Documentation
- Updated README with new requirements, scaffold command usage, and updated code examples